### PR TITLE
Add support for custom callback, width, elevation buttons and navigation

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RobinCode <xv.robincode@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-win-task-dialog = {path = "../"}
+win-task-dialog = { path = "../" }
 
 [build-dependencies]
 embed-resource = "2.1"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -71,6 +71,8 @@ fn main() {
 
     show_msg_dialog("Title", "Hi", "Info", TD_INFORMATION_ICON);
     show_msg_dialog("Title", "!!!", "Error", TD_ERROR_ICON);
+
+    page_navigation();
 }
 
 // Show dynamic text dialog
@@ -152,6 +154,59 @@ fn show_process_bar() {
             (*conf).set_process_bar(i);
         }
     });
+
+    show_task_dialog(&mut conf).unwrap();
+}
+
+fn page_navigation() {
+    unsafe extern "system" fn page1_callback(
+        _: HWND,
+        msg: u32,
+        w_param: usize,
+        _: isize,
+        ref_data: *mut TaskDialogConfig,
+    ) -> i32 {
+        if msg == TDN_NAVIGATED {
+        } else if msg == TDN_BUTTON_CLICKED {
+            // TDN_BUTTON_CLICKED
+
+            // Note that lifetime is limited in Rust objects
+            // and we cannot make new struct in stack here.
+            // Instead we should modify `ref_data`.
+            if w_param as i32 == 1776 {
+                (*ref_data).window_title = "Page #1".to_owned();
+                (*ref_data).main_instruction = "Page #1".to_owned();
+                (*ref_data).buttons = vec![TaskDialogButton {
+                    id: 1777,
+                    text: "Continue".to_owned(),
+                }];
+                (*ref_data).navigate_page(&mut *ref_data);
+                return 1; // S_FALSE
+            } else if w_param as i32 == 1777 {
+                (*ref_data).window_title = "Page #2".to_owned();
+                (*ref_data).main_instruction = "Page #2".to_owned();
+                (*ref_data).buttons = vec![TaskDialogButton {
+                    id: 1776,
+                    text: "Back to page #1".to_owned(),
+                }];
+                (*ref_data).navigate_page(&mut *ref_data);
+                return 1; // S_FALSE
+            }
+        }
+        0
+    }
+
+    let mut conf = TaskDialogConfig {
+        window_title: "Page Navigation".to_owned(),
+        main_instruction: "Page #1".to_owned(),
+        callback: Some(page1_callback),
+        common_buttons: TDCBF_CLOSE_BUTTON,
+        buttons: vec![TaskDialogButton {
+            id: 1777,
+            text: "Continue".to_owned(),
+        }],
+        ..Default::default()
+    };
 
     show_task_dialog(&mut conf).unwrap();
 }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -4,8 +4,22 @@ use std::thread;
 use std::time::Duration;
 use win_task_dialog::*;
 
-fn callback(link: String) {
-    println!("{}", link);
+fn hyperlink_callback(context: &str) {
+    println!("hyperlink_callback: {}", context);
+}
+
+unsafe extern "system" fn callback(
+    hwnd: HWND,
+    msg: u32,
+    w_param: usize,
+    l_param: isize,
+    ref_data: *mut TaskDialogConfig,
+) -> i32 {
+    println!(
+        "callback: hwnd={:?} msg={} wparam={:#X} lparam={:#X} ref_data={:?}",
+        hwnd, msg, w_param, l_param, ref_data
+    );
+    0
 }
 
 fn main() {
@@ -40,7 +54,8 @@ fn main() {
         ],
         main_icon: TD_SHIELD_ICON,
         footer_icon: TD_INFORMATION_ICON,
-        hyperlinkclicked_callback: callback,
+        hyperlink_callback: Some(hyperlink_callback),
+        callback: Some(callback),
         ..TaskDialogConfig::default()
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,8 +292,6 @@ impl Default for TaskDialogResult {
 /** Show task dialog */
 #[cfg(windows)]
 pub fn show_task_dialog(conf: &mut TaskDialogConfig) -> Result<TaskDialogResult, Error> {
-    use std::mem;
-
     let mut result = TaskDialogResult::default();
     let conf_ptr: *mut TaskDialogConfig = conf;
     let conf_long_ptr = conf_ptr as isize;
@@ -388,7 +386,7 @@ pub fn show_task_dialog(conf: &mut TaskDialogConfig) -> Result<TaskDialogResult,
         }
 
         let config = TASKDIALOGCONFIG {
-            cbSize: mem::size_of::<TASKDIALOGCONFIG>() as UINT,
+            cbSize: std::mem::size_of::<TASKDIALOGCONFIG>() as UINT,
             hwndParent: conf.parent,
             hInstance: instance,
             dwFlags: conf.flags,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,11 +144,24 @@ impl TaskDialogConfig {
     pub fn enable_process_bar(&mut self, marquee: bool) {
         if marquee {
             if self.flags & TDF_SHOW_MARQUEE_PROGRESS_BAR != TDF_SHOW_MARQUEE_PROGRESS_BAR {
-                self.flags = self.flags | TDF_SHOW_MARQUEE_PROGRESS_BAR;
+                self.flags |= TDF_SHOW_MARQUEE_PROGRESS_BAR;
             }
         } else {
             if self.flags & TDF_SHOW_PROGRESS_BAR != TDF_SHOW_PROGRESS_BAR {
-                self.flags = self.flags | TDF_SHOW_PROGRESS_BAR;
+                self.flags |= TDF_SHOW_PROGRESS_BAR;
+            }
+        }
+    }
+
+    /** disables progress bar */
+    pub fn disable_process_bar(&mut self, marquee: bool) {
+        if marquee {
+            if self.flags & TDF_SHOW_MARQUEE_PROGRESS_BAR == TDF_SHOW_MARQUEE_PROGRESS_BAR {
+                self.flags &= !TDF_SHOW_MARQUEE_PROGRESS_BAR;
+            }
+        } else {
+            if self.flags & TDF_SHOW_PROGRESS_BAR == TDF_SHOW_PROGRESS_BAR {
+                self.flags &= !TDF_SHOW_PROGRESS_BAR;
             }
         }
     }
@@ -277,6 +290,7 @@ impl TaskDialogConfig {
 #[cfg(not(windows))]
 impl TaskDialogConfig {
     pub fn enable_process_bar(&mut self, _marquee: bool) {}
+    pub fn disable_process_bar(&mut self, marquee: bool) {}
     pub fn set_process_bar_marquee(&mut self, _enable: bool, _time: isize) {}
     pub fn set_process_bar(&mut self, _percentage: usize) {}
     pub fn set_content(&mut self, content: &str) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,8 +188,8 @@ impl TaskDialogConfig {
             return;
         }
         self.content = content.to_string();
-        let content_wchar = U16CString::from_str(content).unwrap();
         unsafe {
+            let content_wchar = U16CString::from_str_unchecked(content);
             SendMessageA(
                 self.dialog_hwnd,
                 TDM_UPDATE_ELEMENT_TEXT,
@@ -205,8 +205,8 @@ impl TaskDialogConfig {
             return;
         }
         self.main_instruction = main_instruction.to_string();
-        let main_instruction_wchar = U16CString::from_str(main_instruction).unwrap();
         unsafe {
+            let main_instruction_wchar = U16CString::from_str_unchecked(main_instruction);
             SendMessageA(
                 self.dialog_hwnd,
                 TDM_UPDATE_ELEMENT_TEXT,
@@ -222,8 +222,8 @@ impl TaskDialogConfig {
             return;
         }
         self.footer = footer.to_string();
-        let footer_wchar = U16CString::from_str(footer).unwrap();
         unsafe {
+            let footer_wchar = U16CString::from_str_unchecked(footer);
             SendMessageA(
                 self.dialog_hwnd,
                 TDM_UPDATE_ELEMENT_TEXT,
@@ -239,8 +239,8 @@ impl TaskDialogConfig {
             return;
         }
         self.expanded_information = expanded_information.to_string();
-        let expanded_information_wchar = U16CString::from_str(expanded_information).unwrap();
         unsafe {
+            let expanded_information_wchar = U16CString::from_str_unchecked(expanded_information);
             SendMessageA(
                 self.dialog_hwnd,
                 TDM_UPDATE_ELEMENT_TEXT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ impl TaskDialogConfig {
 
     /** Set status or animation time of marquee progress bar */
     pub fn set_process_bar_marquee(&mut self, enable: bool, time: isize) {
-        if self.dialog_hwnd == null_mut() {
+        if self.dialog_hwnd.is_null() {
             return;
         }
         unsafe {
@@ -168,7 +168,7 @@ impl TaskDialogConfig {
 
     /** Set the percentage of the progress bar */
     pub fn set_process_bar(&mut self, percentage: usize) {
-        if self.dialog_hwnd == null_mut() {
+        if self.dialog_hwnd.is_null() {
             return;
         }
         unsafe {
@@ -178,7 +178,7 @@ impl TaskDialogConfig {
 
     /** Set the content text */
     pub fn set_content(&mut self, content: &str) {
-        if self.dialog_hwnd == null_mut() {
+        if self.dialog_hwnd.is_null() {
             return;
         }
         let content_wchar = U16CString::from_str(content).unwrap();
@@ -194,7 +194,7 @@ impl TaskDialogConfig {
 
     /** Set the main instruction text */
     pub fn set_main_instruction(&mut self, main_instruction: &str) {
-        if self.dialog_hwnd == null_mut() {
+        if self.dialog_hwnd.is_null() {
             return;
         }
         let main_instruction_wchar = U16CString::from_str(main_instruction).unwrap();
@@ -210,7 +210,7 @@ impl TaskDialogConfig {
 
     /** Set the footer text */
     pub fn set_footer(&mut self, footer: &str) {
-        if self.dialog_hwnd == null_mut() {
+        if self.dialog_hwnd.is_null() {
             return;
         }
         let footer_wchar = U16CString::from_str(footer).unwrap();
@@ -226,7 +226,7 @@ impl TaskDialogConfig {
 
     /** Set the expanded information text */
     pub fn set_expanded_information(&mut self, expanded_information: &str) {
-        if self.dialog_hwnd == null_mut() {
+        if self.dialog_hwnd.is_null() {
             return;
         }
         let expanded_information_wchar = U16CString::from_str(expanded_information).unwrap();
@@ -240,8 +240,9 @@ impl TaskDialogConfig {
         }
     }
 
+    /** Set the button elevation state */
     pub fn set_button_elevation_required_state(&mut self, button_id: usize, enable: bool) {
-        if self.dialog_hwnd == null_mut() {
+        if self.dialog_hwnd.is_null() {
             return;
         }
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,18 +413,23 @@ pub fn execute_task_dialog(
             lp_ref_data: LONG_PTR,
         ) -> HRESULT {
             let conf = std::mem::transmute::<isize, *mut TaskDialogConfig>(lp_ref_data);
-            if msg == TDN_CREATED {
-                (*conf).dialog_hwnd = hwnd;
-            } else if msg == TDN_DESTROYED {
-                (*conf).is_destroyed = true;
-            } else if msg == TDN_HYPERLINK_CLICKED {
-                let link = U16CString::from_ptr_str(_l_param as *const u16)
-                    .to_string()
-                    .unwrap();
-                if let Some(callback) = (*conf).hyperlink_callback {
-                    callback(&link);
+            match msg {
+                TDN_CREATED => {
+                    (*conf).dialog_hwnd = hwnd;
                 }
-            }
+                TDN_DESTROYED => {
+                    (*conf).is_destroyed = true;
+                }
+                TDN_HYPERLINK_CLICKED => {
+                    let link = U16CString::from_ptr_str(_l_param as *const u16)
+                        .to_string()
+                        .unwrap();
+                    if let Some(callback) = (*conf).hyperlink_callback {
+                        callback(&link);
+                    }
+                }
+                _ => {}
+            };
             if let Some(callback) = (*conf).callback {
                 return callback(hwnd, msg, _w_param, _l_param, lp_ref_data as _);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use winapi::shared::minwindef::*;
 pub use winapi::shared::windef::HWND;
 #[cfg(windows)]
 use winapi::shared::winerror::S_OK;
+use winapi::um::commctrl::TDM_SET_BUTTON_ELEVATION_REQUIRED_STATE;
 #[cfg(windows)]
 use winapi::um::commctrl::{
     TASKDIALOGCONFIG_u1, TASKDIALOGCONFIG_u2, TaskDialogIndirect, HRESULT, TASKDIALOGCONFIG,
@@ -238,6 +239,20 @@ impl TaskDialogConfig {
             );
         }
     }
+
+    pub fn set_button_elevation_required_state(&mut self, button_id: usize, enable: bool) {
+        if self.dialog_hwnd == null_mut() {
+            return;
+        }
+        unsafe {
+            SendMessageA(
+                self.dialog_hwnd,
+                TDM_SET_BUTTON_ELEVATION_REQUIRED_STATE,
+                button_id,
+                if enable { 1 } else { 0 },
+            );
+        }
+    }
 }
 
 #[cfg(not(windows))]
@@ -249,6 +264,7 @@ impl TaskDialogConfig {
     pub fn set_main_instruction(&mut self, main_instruction: &str) {}
     pub fn set_footer(&mut self, footer: &str) {}
     pub fn set_expanded_information(&mut self, expanded_information: &str) {}
+    pub fn set_button_elevation_required_state(&mut self, button_id: usize, enable: bool) {}
 }
 
 pub struct TaskDialogButton {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,7 @@ impl TaskDialogConfig {
         if self.dialog_hwnd.is_null() {
             return;
         }
+        self.content = content.to_string();
         let content_wchar = U16CString::from_str(content).unwrap();
         unsafe {
             SendMessageA(
@@ -203,6 +204,7 @@ impl TaskDialogConfig {
         if self.dialog_hwnd.is_null() {
             return;
         }
+        self.main_instruction = main_instruction.to_string();
         let main_instruction_wchar = U16CString::from_str(main_instruction).unwrap();
         unsafe {
             SendMessageA(
@@ -219,6 +221,7 @@ impl TaskDialogConfig {
         if self.dialog_hwnd.is_null() {
             return;
         }
+        self.footer = footer.to_string();
         let footer_wchar = U16CString::from_str(footer).unwrap();
         unsafe {
             SendMessageA(
@@ -235,6 +238,7 @@ impl TaskDialogConfig {
         if self.dialog_hwnd.is_null() {
             return;
         }
+        self.expanded_information = expanded_information.to_string();
         let expanded_information_wchar = U16CString::from_str(expanded_information).unwrap();
         unsafe {
             SendMessageA(


### PR DESCRIPTION
I added supports for

- Custom callback([`TASKDIALOGCONFIG::pfCallback`](https://learn.microsoft.com/windows/win32/api/commctrl/ns-commctrl-taskdialogconfig))s by adding `TaskDialogConfig::callback` field.
- Custom width([`TASKDIALOGCONFIG::cxWidth`](https://learn.microsoft.com/windows/win32/api/commctrl/ns-commctrl-taskdialogconfig)) by adding `TaskDialogConfig::cx_width` field.
- Added `set_button_elevation_required_state` ([`TDM_SET_BUTTON_ELEVATION_REQUIRED_STATE`](https://learn.microsoft.com/windows/win32/controls/tdm-set-button-elevation-required-state)).
- Added `TaskDialogConfig::navigate_page` ([`TDM_NAVIGATE_PAGE`](https://learn.microsoft.com/en-us/windows/win32/controls/tdm-navigate-page)).
  - For backward compatibility, I separated to a `show_task_dialog` into `execute_task_dialog` with option enum parameter `ExecuteOption`. This is necessary since construction of `TaskDialogConfig` into `TASKDIALOGCONFIG` is complex (like string pointers are constructed in a stack and destroyed right after) and concept of lifetime in Rust is difficulty to deal with Windows FFI bindings.
- Added `TaskDialogConfig::disable_process_bar`.

Additionally, I did some code refactors regarding performance improvements and code cleanups:

- Renamed `TaskDialogConfig::hyperlickclicked_callback` into shorter `TaskDialogConfig::hyperlink_callback`. It is shorter but still self-descriptable enough IMO.
- Refactored hyperlink callback parameters from `String` to `&str`.
  - `String` is heap-allocated and too redundant.
- Refactored hyperlink callback function type into `Option<T>`.
  - Instead of having and calling empty closure `|_| {}` it is always better to make it a option.
- Refactored wide-string pointer expressions.
  - We can make use of [`widestring`](https://crates.io/crates/widestring) crate for FFI bindings. `to_os_string` and `from_wide_ptr` indeed works well, however it is always absolutely better to take the encoding serious with the crate.
- Simplified expressions of button mappings.
- Refactored `== null_mut()` expression into [`.is_null()`](https://doc.rust-lang.org/stable/std/ptr/fn.null.html).
- Refactored built-in callback ([`TASKDIALOGCONFIG::pfCallback`](https://learn.microsoft.com/windows/win32/api/commctrl/ns-commctrl-taskdialogconfig)) internals.
  - Make the function itself as `unsafe` to avoid redundant `unsafe` blocks in each `if` blocks.
  - Always reinterpret the `lp_ref_data` as a `*mut TaskDialogConfig`. This shouldn't be effect to compared with the original code and avoids redundant cast in each `if` blocks.
  - Make use of more Rust-like coding style with `match` instead of either `if`, `else` or `else if` expressions.
- Refactored use of `core::ptr::write(x.Y_mut(), z)`, it can be a simplified to `*x.Y_mut() = z`.
- Simplified bitflag operation `x.flag = x.flag | y` into `x.flag |= y`.
- Refactored usage of `U16CString` in `TaskDialogConfig` handlers to use `U16CString::from_str_unchecked` instead of `U16CString::from_str(_).unwrap()`.
- Refactored `TaskDialogConfig` handlers to update self struct fields when respective `set_*` handlers are called.